### PR TITLE
CIV-5274 - Remove handle transaction implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.15.5",
-    "@civic/solana-gateway-react": "^0.9.2-beta.1",
+    "@civic/solana-gateway-react": "^0.9.2",
     "@identity.com/solana-gateway-ts": "^0.8.1",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.15.5",
-    "@civic/solana-gateway-react": "^0.7.0",
+    "@civic/solana-gateway-react": "^0.10.0-alpha.0",
     "@identity.com/solana-gateway-ts": "^0.8.1",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.15.5",
-    "@civic/solana-gateway-react": "^0.10.0-alpha.0",
+    "@civic/solana-gateway-react": "^0.9.2-beta.1",
     "@identity.com/solana-gateway-ts": "^0.8.1",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -306,8 +306,6 @@ const Home = (props: HomeProps) => {
   ) => {
     try {
       setIsUserMinting(true);
-      console.log(`document.getElementById("#identity"): ${document.getElementById("#identity")}`);
-      document.getElementById("#identity")?.click();
       if (wallet.connected && candyMachine?.program && wallet.publicKey) {
         let setupMint: SetupState | undefined;
         if (needTxnSplit && setupTxn === undefined) {
@@ -613,7 +611,6 @@ const Home = (props: HomeProps) => {
                     }
                     clusterUrl={rpcUrl}
                     cluster={cluster}
-                    broadcastTransaction={false}
                     options={{ autoShowModal: false }}
                   >
                     <MintButton

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -29,7 +29,6 @@ import { AlertState, formatNumber, getAtaForMint, toDate } from "./utils";
 import { MintCountdown } from "./MintCountdown";
 import { MintButton } from "./MintButton";
 import { GatewayProvider } from "@civic/solana-gateway-react";
-import { sendTransaction } from "./connection";
 import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
 
 const ConnectButton = styled(WalletDialogButton)`
@@ -307,6 +306,7 @@ const Home = (props: HomeProps) => {
   ) => {
     try {
       setIsUserMinting(true);
+      console.log(`document.getElementById("#identity"): ${document.getElementById("#identity")}`);
       document.getElementById("#identity")?.click();
       if (wallet.connected && candyMachine?.program && wallet.publicKey) {
         let setupMint: SetupState | undefined;
@@ -613,66 +613,6 @@ const Home = (props: HomeProps) => {
                     }
                     clusterUrl={rpcUrl}
                     cluster={cluster}
-                    handleTransaction={async (transaction: Transaction) => {
-                      setIsUserMinting(true);
-                      const userMustSign = transaction.signatures.find((sig) =>
-                        sig.publicKey.equals(wallet.publicKey!)
-                      );
-                      if (userMustSign) {
-                        setAlertState({
-                          open: true,
-                          message: "Please sign one-time Civic Pass issuance",
-                          severity: "info",
-                        });
-                        try {
-                          transaction = await wallet.signTransaction!(
-                            transaction
-                          );
-                        } catch (e) {
-                          setAlertState({
-                            open: true,
-                            message: "User cancelled signing",
-                            severity: "error",
-                          });
-                          // setTimeout(() => window.location.reload(), 2000);
-                          setIsUserMinting(false);
-                          throw e;
-                        }
-                      } else {
-                        setAlertState({
-                          open: true,
-                          message: "Refreshing Civic Pass",
-                          severity: "info",
-                        });
-                      }
-                      try {
-                        await sendTransaction(
-                          props.connection,
-                          wallet,
-                          transaction,
-                          [],
-                          true,
-                          "confirmed"
-                        );
-                        setAlertState({
-                          open: true,
-                          message: "Please sign minting",
-                          severity: "info",
-                        });
-                      } catch (e) {
-                        setAlertState({
-                          open: true,
-                          message:
-                            "Solana dropped the transaction, please try again",
-                          severity: "warning",
-                        });
-                        console.error(e);
-                        // setTimeout(() => window.location.reload(), 2000);
-                        setIsUserMinting(false);
-                        throw e;
-                      }
-                      await onMint();
-                    }}
                     broadcastTransaction={false}
                     options={{ autoShowModal: false }}
                   >

--- a/src/MintButton.tsx
+++ b/src/MintButton.tsx
@@ -42,6 +42,7 @@ export const MintButton = ({
   const { requestGatewayToken, gatewayStatus } = useGateway();
   const [webSocketSubscriptionId, setWebSocketSubscriptionId] = useState(-1);
   const [clicked, setClicked] = useState(false);
+  const [waitForActiveToken, setWaitForActiveToken] = useState(false);
 
   const getMintButtonContent = () => {
     if (candyMachine?.state.isSoldOut) {
@@ -93,8 +94,20 @@ export const MintButton = ({
     ) {
       setIsMinting(true);
     }
-    console.log("change: ", gatewayStatus);
-  }, [setIsMinting, previousGatewayStatus, gatewayStatus]);
+    console.log("change: ", GatewayStatus[gatewayStatus]);
+  }, [waitForActiveToken, previousGatewayStatus, gatewayStatus]);
+
+  useEffect(() => {
+    if (
+      waitForActiveToken &&
+      gatewayStatus === GatewayStatus.ACTIVE
+    ) {
+      console.log("Minting after token active");
+      setWaitForActiveToken(false);
+      onMint();
+    }
+
+  }, [waitForActiveToken, gatewayStatus, onMint]);
 
   return (
     <CTAButton
@@ -108,6 +121,7 @@ export const MintButton = ({
               await onMint();
             } else {
               // setIsMinting(true);
+              setWaitForActiveToken(true);
               await requestGatewayToken();
               console.log("after: ", gatewayStatus);
             }

--- a/src/MintButton.tsx
+++ b/src/MintButton.tsx
@@ -11,6 +11,7 @@ import {
   onGatewayTokenChange,
   removeAccountChangeListener,
 } from "@identity.com/solana-gateway-ts";
+import { CIVIC_GATEKEEPER_NETWORK } from "./utils";
 
 export const CTAButton = styled(Button)`
   width: 100%;
@@ -116,7 +117,7 @@ export const MintButton = ({
         if (candyMachine?.state.isActive && candyMachine?.state.gatekeeper) {
           const network =
             candyMachine.state.gatekeeper.gatekeeperNetwork.toBase58();
-          if (network === "ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6") {
+          if (network === CIVIC_GATEKEEPER_NETWORK) {
             if (gatewayStatus === GatewayStatus.ACTIVE) {
               await onMint();
             } else {

--- a/src/candy-machine.ts
+++ b/src/candy-machine.ts
@@ -124,7 +124,7 @@ export const awaitTransactionSignatureConfirmation = async (
 
   //@ts-ignore
   try {
-    connection.removeSignatureListener(subId);
+    await connection.removeSignatureListener(subId);
   } catch (e) {
     // ignore
   }

--- a/src/connection.tsx
+++ b/src/connection.tsx
@@ -542,7 +542,7 @@ async function awaitTransactionSignatureConfirmation(
 
   //@ts-ignore
   try {
-    connection.removeSignatureListener(subId);
+    await connection.removeSignatureListener(subId);
   } catch (e) {
     // ignore
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,8 @@ export const CIVIC = new anchor.web3.PublicKey(
   "gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs"
 );
 
+export const CIVIC_GATEKEEPER_NETWORK = 'ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6';
+
 export const getAtaForMint = async (
   mint: anchor.web3.PublicKey,
   buyer: anchor.web3.PublicKey

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,22 +1683,22 @@
     eip1193-provider "^1.0.1"
     js-sha3 "^0.8.0"
 
-"@civic/common-gateway-react@^0.4.1-beta.1":
-  version "0.4.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.4.1-beta.1.tgz#c5ef2076d10fcdc4ef8a5393f4204d76f416ccae"
-  integrity sha512-D/vQpUWNwu5z1pNT2OyoiG/tRGh8Qi7QLb7V5JmOwSkjS2WPRN4u0WxaNcLpI/aEU/ihQE7QnlwUgw5xzFWbUg==
+"@civic/common-gateway-react@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.4.1.tgz#fe03923abe76c1ec5634f8c6212d842ccb6a5a10"
+  integrity sha512-RI7gihmJivuF/HpLf7PLdTKIPDaN6yANPY9afvIHI9Lrs/+H1Fz5Z9C/BA/fetkrBTBSH9tC14w+wKpAC8povA==
   dependencies:
     fetch-retry-ts "^1.1.24"
     iframe-resizer-react "^1.1.0"
     ramda "^0.27.1"
     styled-components "^5.3.1"
 
-"@civic/solana-gateway-react@^0.9.2-beta.1":
-  version "0.9.2-beta.1"
-  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.9.2-beta.1.tgz#757b27b118105f4b14d99d4cbab27d867f6a1416"
-  integrity sha512-Gv9AoJNEwxioZvQVmN1gb2+9+g20/0OAyjaxqA3XWaniQcud767QgLSloMuXpMYZQg/tNyUcryafzEjEZfzfFA==
+"@civic/solana-gateway-react@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.9.2.tgz#b88a5a2033878bff274355dcf363546a178e2432"
+  integrity sha512-sAaFkGeo3tgzZwTG3Nw1yyt8MnONQWcskJBEFoPTbcwwTvnUl/i8bXI1SnAGON+D/LuQbssllOD8zPm86UHuLA==
   dependencies:
-    "@civic/common-gateway-react" "^0.4.1-beta.1"
+    "@civic/common-gateway-react" "^0.4.1"
     "@identity.com/prove-solana-wallet" "0.2.9"
     "@identity.com/solana-gateway-ts" "^0.7.0"
     "@solana/web3.js" "1.39.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,25 +1683,25 @@
     eip1193-provider "^1.0.1"
     js-sha3 "^0.8.0"
 
-"@civic/common-gateway-react@^0.1.9":
-  version "0.1.10"
-  resolved "https://registry.npmjs.org/@civic/common-gateway-react/-/common-gateway-react-0.1.10.tgz"
-  integrity sha512-JMEqhv0/wmdLB3HrCM+7NRltyuneeFiNwTWDff5ZKHvAfhp+zCA2TmJEnM3RyBkT4i9d3RN1P1no91gnpZqy3w==
+"@civic/common-gateway-react@^0.5.0-alpha.0":
+  version "0.5.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.5.0-alpha.0.tgz#7b04a4a1050eab06b982b39b99b60c1415dc1a97"
+  integrity sha512-bySeQLOKIPbvPU7Nx1+tSLE8gI7GYnf3HpFtdOZJHRI3z054/bqOiusSQgUH8tG1SqmvBxuXtPxpEB90plXOXg==
   dependencies:
     fetch-retry-ts "^1.1.24"
     iframe-resizer-react "^1.1.0"
     ramda "^0.27.1"
     styled-components "^5.3.1"
 
-"@civic/solana-gateway-react@^0.7.0":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.7.5.tgz#2c2a222cb007aa8e8803412c01edfcba95a8fbb3"
-  integrity sha512-WVlQSNH5eAZw9/Z9uwTpLUmQzm+uywNMt1ICUSDUY6FsvW0YuCl5grBNbb7ggpJH7UPL1YKr1M06RofWKfnH3g==
+"@civic/solana-gateway-react@^0.10.0-alpha.0":
+  version "0.10.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.10.0-alpha.0.tgz#8f3f7909834b347b3b56b1dacffd728890e7e9df"
+  integrity sha512-+/F8w0nwjm+TMdDjjf4O5nzmbVssGU5X/rAZgdNgHkjoKsaif3HtLcDuz2FeAKwCCCl+h1LD+6t9RqQioeVung==
   dependencies:
-    "@civic/common-gateway-react" "^0.1.9"
-    "@identity.com/prove-solana-wallet" "^0.2.3"
+    "@civic/common-gateway-react" "^0.5.0-alpha.0"
+    "@identity.com/prove-solana-wallet" "0.2.9"
     "@identity.com/solana-gateway-ts" "^0.7.0"
-    "@solana/web3.js" "^1.33.0"
+    "@solana/web3.js" "1.39.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -1761,21 +1761,6 @@
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
-    strip-json-comments "^3.1.1"
-
-"@eslint/eslintrc@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
-  integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.3.2"
-    espree "^9.3.2"
-    globals "^13.15.0"
-    ignore "^5.2.0"
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
 "@ethersproject/bytes@^5.5.0":
@@ -1845,26 +1830,17 @@
     debug "^4.1.1"
     minimatch "^3.0.4"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
-  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
-  dependencies:
-    "@humanwhocodes/object-schema" "^1.2.1"
-    debug "^4.1.1"
-    minimatch "^3.0.4"
-
-"@humanwhocodes/object-schema@^1.2.0", "@humanwhocodes/object-schema@^1.2.1":
+"@humanwhocodes/object-schema@^1.2.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@identity.com/prove-solana-wallet@^0.2.3":
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/@identity.com/prove-solana-wallet/-/prove-solana-wallet-0.2.4.tgz"
-  integrity sha512-DsGyu9l52//fmhsC1GR+0ylsaGxOgo8e7UEEF3gTHFXECcHgXatuhyBafMO4Gm9a7EHdC22fjgp1MM9hq/rN3A==
+"@identity.com/prove-solana-wallet@0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@identity.com/prove-solana-wallet/-/prove-solana-wallet-0.2.9.tgz#b75419a1a7baaed25ac489055c13188c295fcfd4"
+  integrity sha512-BpDyNbMp1j+yGlGooTd/D8Qs+DtkblvPqBMRjK9pMI2dG6HcAYUaG5NFt+yB9mfl1sGu10LuTBGqL5KS4Ggu8Q==
   dependencies:
-    "@solana/web3.js" "^1.22.0"
+    "@solana/web3.js" "1.39.0"
     bs58 "^4.0.1"
 
 "@identity.com/solana-gateway-ts@^0.7.0":
@@ -2570,6 +2546,26 @@
     "@solana/wallet-adapter-solong" "^0.7.0"
     "@solana/wallet-adapter-tokenpocket" "^0.2.0"
     "@solana/wallet-adapter-torus" "^0.8.0"
+
+"@solana/web3.js@1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.39.0.tgz#67183c36709e33441f8c3d44b0b744e4953f0851"
+  integrity sha512-6Z7I7oGpnCDqcj9em3/QajBFBORuUtIFaE29KjU4z39+nLshs+9oysDgp2aPMdiEPCNF1ioNQLdBsjD4x1Pv3w==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@ethersproject/sha2" "^5.5.0"
+    "@solana/buffer-layout" "^4.0.0"
+    bn.js "^5.0.0"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    cross-fetch "^3.1.4"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
 
 "@solana/web3.js@^1.17.0":
   version "1.44.0"
@@ -3630,7 +3626,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
+acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -3655,7 +3651,7 @@ acorn@^8.2.4, acorn@^8.4.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
-acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.5.0:
   version "8.7.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -3806,11 +3802,6 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -5604,7 +5595,7 @@ debug@^3.1.1, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.0.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -6377,14 +6368,6 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
-  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^5.2.0"
-
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz"
@@ -6472,47 +6455,6 @@ eslint@^7.11.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^8.19.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.19.0.tgz#7342a3cbc4fbc5c106a1eefe0fd0b50b6b1a7d28"
-  integrity sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==
-  dependencies:
-    "@eslint/eslintrc" "^1.3.0"
-    "@humanwhocodes/config-array" "^0.9.2"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.3.2"
-    doctrine "^3.0.0"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.1"
-    eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.3.0"
-    espree "^9.3.2"
-    esquery "^1.4.0"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^6.0.1"
-    globals "^13.15.0"
-    ignore "^5.2.0"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^4.1.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.1.2"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    regexpp "^3.2.0"
-    strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
-
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz"
@@ -6521,15 +6463,6 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
-
-espree@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
-  integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
-  dependencies:
-    acorn "^8.7.1"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -7162,13 +7095,6 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
-
 glob@^7.0.3:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
@@ -7213,13 +7139,6 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
-globals@^13.15.0:
-  version "13.16.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.16.0.tgz#9be4aca28f311aaeb974ea54978ebbb5e35ce46a"
-  integrity sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==
-  dependencies:
-    type-fest "^0.20.2"
 
 globals@^13.6.0, globals@^13.9.0:
   version "13.15.0"
@@ -8741,13 +8660,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsdom@^16.4.0:
   version "16.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,22 +1683,22 @@
     eip1193-provider "^1.0.1"
     js-sha3 "^0.8.0"
 
-"@civic/common-gateway-react@^0.5.0-alpha.0":
-  version "0.5.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.5.0-alpha.0.tgz#7b04a4a1050eab06b982b39b99b60c1415dc1a97"
-  integrity sha512-bySeQLOKIPbvPU7Nx1+tSLE8gI7GYnf3HpFtdOZJHRI3z054/bqOiusSQgUH8tG1SqmvBxuXtPxpEB90plXOXg==
+"@civic/common-gateway-react@^0.4.1-beta.1":
+  version "0.4.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.4.1-beta.1.tgz#c5ef2076d10fcdc4ef8a5393f4204d76f416ccae"
+  integrity sha512-D/vQpUWNwu5z1pNT2OyoiG/tRGh8Qi7QLb7V5JmOwSkjS2WPRN4u0WxaNcLpI/aEU/ihQE7QnlwUgw5xzFWbUg==
   dependencies:
     fetch-retry-ts "^1.1.24"
     iframe-resizer-react "^1.1.0"
     ramda "^0.27.1"
     styled-components "^5.3.1"
 
-"@civic/solana-gateway-react@^0.10.0-alpha.0":
-  version "0.10.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.10.0-alpha.0.tgz#8f3f7909834b347b3b56b1dacffd728890e7e9df"
-  integrity sha512-+/F8w0nwjm+TMdDjjf4O5nzmbVssGU5X/rAZgdNgHkjoKsaif3HtLcDuz2FeAKwCCCl+h1LD+6t9RqQioeVung==
+"@civic/solana-gateway-react@^0.9.2-beta.1":
+  version "0.9.2-beta.1"
+  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.9.2-beta.1.tgz#757b27b118105f4b14d99d4cbab27d867f6a1416"
+  integrity sha512-Gv9AoJNEwxioZvQVmN1gb2+9+g20/0OAyjaxqA3XWaniQcud767QgLSloMuXpMYZQg/tNyUcryafzEjEZfzfFA==
   dependencies:
-    "@civic/common-gateway-react" "^0.5.0-alpha.0"
+    "@civic/common-gateway-react" "^0.4.1-beta.1"
     "@identity.com/prove-solana-wallet" "0.2.9"
     "@identity.com/solana-gateway-ts" "^0.7.0"
     "@solana/web3.js" "1.39.0"


### PR DESCRIPTION
The new version of the Civic React Component implements an internal client-sends handleTransaction function, meaning that this complexity can be removed from dApp implementations.

This PR removes ‘handleTransaction’ as a Civic GatewayProvider parameter and instead adds a smaller, cleaner useEffect to use the GatewayStatus going ACTIVE to trigger minting. It also bump the Civic React Component version to the latest, 0.9.2

Also in this PR is a bug fix for a bug where the UI was hanging in some error cases because of an unhandled promise in a call to `connection.removeSignatureListener(subId);`